### PR TITLE
Fixes Economy Issues

### DIFF
--- a/src/act_obj.c
+++ b/src/act_obj.c
@@ -2374,10 +2374,8 @@ void do_sacrifice( CHAR_DATA* ch, const char* argument)
    {
       mudstrlcpy( name, "Thoric", 50 );
    }
-   ch->gold += 1;
    if( obj->item_type == ITEM_CORPSE_NPC || obj->item_type == ITEM_CORPSE_PC )
       adjust_favor( ch, 5, 1 );
-   ch_printf( ch, "%s gives you one gold coin for your sacrifice.\r\n", name );
 
    if( obj->item_type == ITEM_PAPER )
 	   snprintf( buf, MAX_STRING_LENGTH, "$n sacrifices a note to %s.", name );

--- a/src/makeobjs.c
+++ b/src/makeobjs.c
@@ -132,22 +132,8 @@ OBJ_DATA *make_corpse( CHAR_DATA * ch, CHAR_DATA * killer )
       name = ch->short_descr;
       corpse = create_object( get_obj_index( OBJ_VNUM_CORPSE_NPC ), 0 );
       corpse->timer = 6;
-      if( ch->gold > 0 )
-      {
-         if( ch->in_room )
-         {
-            ch->in_room->area->gold_looted += ch->gold;
-            sysdata.global_looted += ch->gold / 100;
-         }
-         obj_to_obj( create_money( ch->gold ), corpse );
-         ch->gold = 0;
-      }
-
-/* Cannot use these!  They are used.
-	corpse->value[0] = (int)ch->pIndexData->vnum;
-	corpse->value[1] = (int)ch->max_hit;
-*/
-/*	Using corpse cost to cheat, since corpses not sellable */
+   
+/* Using corpse cost to cheat, since corpses not sellable */
       corpse->cost = ( -( int )ch->pIndexData->vnum );
       corpse->value[2] = corpse->timer;
    }

--- a/src/shops.c
+++ b/src/shops.c
@@ -740,22 +740,12 @@ void do_list( CHAR_DATA* ch, const char* argument)
             if( !found )
             {
                found = TRUE;
-               send_to_pager( "[Lv Price] Item\r\n", ch );
+               send_to_pager( "&G[Item]                      &c[Tier]     &Y[Price]\r\n", ch );
+	       send_to_pager("&W-------------------------------------------------------------\r\n", ch);
             }
 
-            if( obj->level <= upper )
-            {
-               pager_printf( ch, "%s%2d%s\r\n", divleft, upper, divright );
-               upper = -1;
-            }
 
-            if( obj->level < lower )
-            {
-               pager_printf( ch, "%s%2d%s\r\n", divleft, lower, divright );
-               lower = -1;
-            }
-
-            pager_printf( ch, "[%2d %5d] %s.\r\n", obj->level, cost, capitalize( obj->short_descr ) );
+            pager_printf( ch, "&G%-30s &c%d        &Y%d&W\r\n", capitalize( obj->short_descr), obj->tier, cost  );
          }
       }
 
@@ -782,7 +772,6 @@ void do_sell( CHAR_DATA* ch, const char* argument)
    CHAR_DATA *keeper;
    OBJ_DATA *obj;
    int cost;
-
    one_argument( argument, arg );
 
    if( arg[0] == '\0' )
@@ -822,7 +811,9 @@ void do_sell( CHAR_DATA* ch, const char* argument)
       return;
    }
 
-   if( ( cost = get_cost( ch, keeper, obj, FALSE ) ) <= 0 )
+   cost = obj->cost/10;
+
+   if( ( cost  <= 0 ))
    {
       act( AT_ACTION, "$n looks uninterested in $p.", keeper, obj, ch, TO_VICT );
       return;


### PR DESCRIPTION
gold no longer loads on mob. gold will have to be an item on the mob itself.
shops now take object value into the equation when selling.
sacrificing no longer gives you a gold coin.

for the most part, the economy should guide itself now, based off loot
and mob shops. It should prove to be a lot less inflated.